### PR TITLE
feat(sync): stable jellyfin matching via external IDs with heal-on-match

### DIFF
--- a/backend/app/client/jellyfin_client.py
+++ b/backend/app/client/jellyfin_client.py
@@ -217,7 +217,7 @@ async def fetch_jellyfin_episodes_for_user_all(
                 params={
                     "IncludeItemTypes": "Episode",
                     "Recursive": "true",
-                    "Fields": "UserData",
+                    "Fields": "UserData,ProviderIds,ParentIndexNumber,IndexNumber,SeriesId,SeasonId",
                     "ImageTypeLimit": "0",
                 },
                 limit=100,
@@ -228,3 +228,42 @@ async def fetch_jellyfin_episodes_for_user_all(
         except Exception as e:
             await _handle_jellyfin_error(e)
             raise
+
+
+async def fetch_jellyfin_series_by_ids(
+    url: str,
+    api_key: str,
+    user_jellyfin_id: str,
+    series_jellyfin_ids: list[str],
+) -> list[dict[str, Any]]:
+    if not series_jellyfin_ids:
+        return []
+
+    chunk_size = 50
+    headers = {"X-Emby-Token": api_key}
+    base_url = f"{url}/Users/{user_jellyfin_id}/Items"
+    all_items: list[dict[str, Any]] = []
+
+    async with httpx.AsyncClient() as client:
+        try:
+            for i in range(0, len(series_jellyfin_ids), chunk_size):
+                chunk = series_jellyfin_ids[i : i + chunk_size]
+                items = await fetch_paginated(
+                    client=client,
+                    url=base_url,
+                    headers=headers,
+                    params={
+                        "Ids": ",".join(chunk),
+                        "IncludeItemTypes": "Series",
+                        "Fields": "ProviderIds",
+                        "ImageTypeLimit": "0",
+                    },
+                    limit=100,
+                    timeout=60.0,
+                    service_name=f"Jellyfin Series by IDs (chunk {i // chunk_size + 1})",
+                )
+                all_items.extend(items)
+        except Exception as e:
+            await _handle_jellyfin_error(e)
+            raise
+    return all_items

--- a/backend/app/services/movie_utils.py
+++ b/backend/app/services/movie_utils.py
@@ -217,3 +217,21 @@ def update_existing_movie(
         logger.info("Updated movie '%s' with new data %s", title, source_info)
 
     return was_updated
+
+
+def resolve_movie_from_indexes(
+    *,
+    jellyfin_id: str | None,
+    tmdb_id: str | None,
+    imdb_id: str | None,
+    by_jellyfin_id: dict[str, Movie],
+    by_tmdb_id: dict[str, Movie],
+    by_imdb_id: dict[str, Movie],
+) -> Movie | None:
+    if jellyfin_id and jellyfin_id in by_jellyfin_id:
+        return by_jellyfin_id[jellyfin_id]
+    if tmdb_id and tmdb_id in by_tmdb_id:
+        return by_tmdb_id[tmdb_id]
+    if imdb_id and imdb_id in by_imdb_id:
+        return by_imdb_id[imdb_id]
+    return None

--- a/backend/app/services/series_utils.py
+++ b/backend/app/services/series_utils.py
@@ -281,3 +281,21 @@ def update_existing_series(
         ids_info = f" ({', '.join(updated_ids)})" if updated_ids else ""
         logger.info("Updated series '%s'%s%s", title, ids_info, source_info)
     return was_updated
+
+
+def resolve_series_from_indexes(
+    *,
+    jellyfin_id: str | None,
+    tvdb_id: str | None,
+    imdb_id: str | None,
+    by_jellyfin_id: dict[str, Series],
+    by_tvdb_id: dict[str, Series],
+    by_imdb_id: dict[str, Series],
+) -> Series | None:
+    if jellyfin_id and jellyfin_id in by_jellyfin_id:
+        return by_jellyfin_id[jellyfin_id]
+    if tvdb_id and tvdb_id in by_tvdb_id:
+        return by_tvdb_id[tvdb_id]
+    if imdb_id and imdb_id in by_imdb_id:
+        return by_imdb_id[imdb_id]
+    return None

--- a/backend/app/services/sync_jellyfin_watched_movies_service.py
+++ b/backend/app/services/sync_jellyfin_watched_movies_service.py
@@ -7,6 +7,7 @@ from app.models.media import Movie
 from app.models.schedule import ServiceType
 from app.models.user import User, WatchHistory, WatchStatus
 from app.schemas.jellyfin import JellyfinWatchedMoviesResponse
+from app.services.movie_utils import resolve_movie_from_indexes
 from app.services.service_config_repository import get_decrypted_config
 from app.utils.datetime import parse_datetime
 
@@ -120,28 +121,38 @@ async def sync_jellyfin_watched_movies(session: AsyncSession) -> JellyfinWatched
                 total_movies_processed += 1
 
                 # Find movie into saved data
-                movie: Movie | None = None
                 jellyfin_id = str(movie_data.get("Id")) if movie_data.get("Id") else None
+                provider_ids = movie_data.get("ProviderIds", {}) or {}
+                tmdb_id = str(provider_ids.get("Tmdb")) if provider_ids.get("Tmdb") else None
+                imdb_id = provider_ids.get("Imdb") or None
 
-                if jellyfin_id and jellyfin_id in movies_by_jellyfin_id:
-                    movie = movies_by_jellyfin_id[jellyfin_id]
-                else:
-                    provider_ids = movie_data.get("ProviderIds", {})
-                    tmdb_id = str(provider_ids.get("Tmdb")) if provider_ids.get("Tmdb") else None
-                    imdb_id = provider_ids.get("Imdb")
-
-                    if tmdb_id and tmdb_id in movies_by_tmdb_id:
-                        movie = movies_by_tmdb_id[tmdb_id]
-                    elif imdb_id and imdb_id in movies_by_imdb_id:
-                        movie = movies_by_imdb_id[imdb_id]
-
+                movie = resolve_movie_from_indexes(
+                    jellyfin_id=jellyfin_id,
+                    tmdb_id=tmdb_id,
+                    imdb_id=imdb_id,
+                    by_jellyfin_id=movies_by_jellyfin_id,
+                    by_tmdb_id=movies_by_tmdb_id,
+                    by_imdb_id=movies_by_imdb_id,
+                )
                 if not movie:
-                    logger.debug(
-                        "Movie not found in database: %s (Jellyfin ID: %s)",
+                    logger.warning(
+                        "Movie not found in DB: name=%s jellyfin_id=%s tmdb=%s imdb=%s",
                         movie_data.get("Name"),
                         jellyfin_id,
+                        tmdb_id,
+                        imdb_id,
                     )
                     continue
+
+                if jellyfin_id and movie.jellyfin_id != jellyfin_id:
+                    logger.info(
+                        "Healing Movie.jellyfin_id: id=%s old=%s new=%s",
+                        movie.id,
+                        movie.jellyfin_id,
+                        jellyfin_id,
+                    )
+                    movie.jellyfin_id = jellyfin_id
+                    movies_by_jellyfin_id[jellyfin_id] = movie
 
                 # Data about watching
                 user_data = movie_data.get("UserData", {})
@@ -196,19 +207,22 @@ async def sync_jellyfin_watched_movies(session: AsyncSession) -> JellyfinWatched
                     logger.debug("Added: %s", movie.id)
 
             # 4b. Dropped detection: фильмы, исчезнувшие из Jellyfin
-            jellyfin_media_ids = set()
+            jellyfin_media_ids: set[int] = set()
             for movie_data in movies_data:
-                jellyfin_id = str(movie_data.get("Id")) if movie_data.get("Id") else None
-                if jellyfin_id and jellyfin_id in movies_by_jellyfin_id:
-                    jellyfin_media_ids.add(movies_by_jellyfin_id[jellyfin_id].id)
-                else:
-                    provider_ids = movie_data.get("ProviderIds", {})
-                    tmdb_id = str(provider_ids.get("Tmdb")) if provider_ids.get("Tmdb") else None
-                    imdb_id = provider_ids.get("Imdb")
-                    if tmdb_id and tmdb_id in movies_by_tmdb_id:
-                        jellyfin_media_ids.add(movies_by_tmdb_id[tmdb_id].id)
-                    elif imdb_id and imdb_id in movies_by_imdb_id:
-                        jellyfin_media_ids.add(movies_by_imdb_id[imdb_id].id)
+                jf_id = str(movie_data.get("Id")) if movie_data.get("Id") else None
+                pids = movie_data.get("ProviderIds", {}) or {}
+                t_id = str(pids.get("Tmdb")) if pids.get("Tmdb") else None
+                i_id = pids.get("Imdb") or None
+                resolved = resolve_movie_from_indexes(
+                    jellyfin_id=jf_id,
+                    tmdb_id=t_id,
+                    imdb_id=i_id,
+                    by_jellyfin_id=movies_by_jellyfin_id,
+                    by_tmdb_id=movies_by_tmdb_id,
+                    by_imdb_id=movies_by_imdb_id,
+                )
+                if resolved:
+                    jellyfin_media_ids.add(resolved.id)
 
             for media_id, wh in current_watches.items():
                 if (

--- a/backend/app/services/sync_jellyfin_watched_series_service.py
+++ b/backend/app/services/sync_jellyfin_watched_series_service.py
@@ -1,13 +1,17 @@
-from sqlalchemy import insert, select
+from sqlalchemy import insert, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.client.jellyfin_client import fetch_jellyfin_episodes_for_user_all
+from app.client.jellyfin_client import (
+    fetch_jellyfin_episodes_for_user_all,
+    fetch_jellyfin_series_by_ids,
+)
 from app.config import logger
-from app.models.media import Episode, Season
+from app.models.media import Episode, Season, Series
 from app.models.schedule import ServiceType
 from app.models.user import User, WatchHistory, WatchStatus
 from app.schemas.jellyfin import JellyfinWatchedSeriesResponse
+from app.services.series_utils import resolve_series_from_indexes
 from app.services.service_config_repository import get_decrypted_config
 from app.utils.datetime import parse_datetime
 
@@ -42,7 +46,7 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
         logger.info("Processing episodes for user %s", user.username)
 
         try:
-            # 2. Get all episodes by user from Jellyfin (with pagination into func)
+            # Step 1: get flat list of episodes from Jellyfin
             episodes_data = await fetch_jellyfin_episodes_for_user_all(
                 url, api_key, user.jellyfin_user_id
             )
@@ -51,38 +55,182 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
                 logger.info("No episodes found for user %s", user.username)
                 continue
 
-            # --- episodes from DB ---
-            jellyfin_ids = [ep["Id"] for ep in episodes_data if ep.get("Id")]
+            # Step 2: collect unique jellyfin series IDs from episodes
+            series_jellyfin_ids = list(
+                {ep["SeriesId"] for ep in episodes_data if ep.get("SeriesId")}
+            )
+
+            # Step 3: fetch provider IDs for those series from Jellyfin
+            series_items = await fetch_jellyfin_series_by_ids(
+                url, api_key, user.jellyfin_user_id, series_jellyfin_ids
+            )
+            series_provider_ids: dict[str, dict[str, str]] = {}
+            for item in series_items:
+                jf_id = item.get("Id")
+                if jf_id:
+                    series_provider_ids[jf_id] = item.get("ProviderIds", {}) or {}
+
+            # Step 4: load Series from DB in a single query
+            tvdb_ids = {v.get("Tvdb") for v in series_provider_ids.values() if v.get("Tvdb")}
+            imdb_ids = {v.get("Imdb") for v in series_provider_ids.values() if v.get("Imdb")}
+            jf_ids_set = set(series_jellyfin_ids)
+
+            series_result = await session.execute(
+                select(Series).where(
+                    or_(
+                        Series.jellyfin_id.in_(jf_ids_set),
+                        Series.tvdb_id.in_(tvdb_ids),
+                        Series.imdb_id.in_(imdb_ids),
+                    )
+                )
+            )
+            db_series_list = series_result.scalars().all()
+
+            by_jf_id: dict[str, Series] = {
+                s.jellyfin_id: s for s in db_series_list if s.jellyfin_id
+            }
+            by_tvdb_id: dict[str, Series] = {s.tvdb_id: s for s in db_series_list if s.tvdb_id}
+            by_imdb_id: dict[str, Series] = {s.imdb_id: s for s in db_series_list if s.imdb_id}
+
+            # Step 5: resolve each jellyfin_series_id to a Series object with heal
+            series_by_jellyfin_series_id: dict[str, Series] = {}
+            unmatched_series_ids: set[str] = set()
+
+            for jf_sid in series_jellyfin_ids:
+                pids = series_provider_ids.get(jf_sid, {})
+                tvdb = pids.get("Tvdb")
+                imdb = pids.get("Imdb")
+
+                series = resolve_series_from_indexes(
+                    jellyfin_id=jf_sid,
+                    tvdb_id=tvdb,
+                    imdb_id=imdb,
+                    by_jellyfin_id=by_jf_id,
+                    by_tvdb_id=by_tvdb_id,
+                    by_imdb_id=by_imdb_id,
+                )
+                if not series:
+                    if jf_sid not in unmatched_series_ids:
+                        logger.warning(
+                            "Series not found: jellyfin_series_id=%s tvdb=%s imdb=%s",
+                            jf_sid,
+                            tvdb,
+                            imdb,
+                        )
+                        unmatched_series_ids.add(jf_sid)
+                    continue
+
+                # heal Series.jellyfin_id
+                if series.jellyfin_id != jf_sid:
+                    logger.info(
+                        "Healing Series.jellyfin_id: id=%s old=%s new=%s",
+                        series.id,
+                        series.jellyfin_id,
+                        jf_sid,
+                    )
+                    series.jellyfin_id = jf_sid
+                    by_jf_id[jf_sid] = series
+
+                series_by_jellyfin_series_id[jf_sid] = series
+
+            # Step 6: load seasons and episodes for resolved series
+            resolved_series = list(series_by_jellyfin_series_id.values())
+            resolved_series_ids = [s.id for s in resolved_series]
+
+            seasons_result = await session.execute(
+                select(Season).where(Season.series_id.in_(resolved_series_ids))
+            )
+            seasons = seasons_result.scalars().all()
 
             episodes_result = await session.execute(
                 select(Episode)
-                .options(selectinload(Episode.season).selectinload(Season.series))
-                .where(Episode.jellyfin_id.in_(jellyfin_ids))
+                .options(selectinload(Episode.season))
+                .where(Episode.season_id.in_([s.id for s in seasons]))
             )
-            episodes_by_jellyfin_id = {e.jellyfin_id: e for e in episodes_result.scalars()}
+            db_episodes = episodes_result.scalars().all()
+            # index: (series_id, season_number, episode_number) -> Episode
+            episodes_by_triple: dict[tuple[int, int, int], Episode] = {}
+            for ep in db_episodes:
+                season_obj = ep.season
+                if season_obj:
+                    key = (season_obj.series_id, season_obj.number, ep.number)
+                    episodes_by_triple[key] = ep
 
+            # Step 7: load watch history for user
             watch_history_result = await session.execute(
                 select(WatchHistory).where(
                     WatchHistory.user_id == user.id,
                     WatchHistory.episode_id.isnot(None),
                 )
             )
-            watch_by_episode_id = {wh.episode_id: wh for wh in watch_history_result.scalars()}
+            watch_by_episode_id: dict[int, WatchHistory] = {
+                wh.episode_id: wh
+                for wh in watch_history_result.scalars()
+                if wh.episode_id is not None
+            }
             to_insert = []
+            resolved_episode_ids: set[int] = set()
 
+            # Step 8: main loop over episodes
             for ep_data in episodes_data:
-                jellyfin_id = ep_data.get("Id")
-                episode = episodes_by_jellyfin_id.get(jellyfin_id)
-                if not episode:
+                jf_ep_id = ep_data.get("Id")
+                jf_series_id = ep_data.get("SeriesId")
+                season_num = ep_data.get("ParentIndexNumber")
+                ep_num = ep_data.get("IndexNumber")
+
+                if (
+                    not jf_series_id
+                    or not isinstance(season_num, int)
+                    or not isinstance(ep_num, int)
+                ):
+                    logger.warning("Skip episode (incomplete payload): jellyfin_ep_id=%s", jf_ep_id)
                     continue
 
-                if not episode.season or not episode.season.series:
-                    logger.error(
-                        "Broken episode relations: episode_id=%s jellyfin_id=%s",
-                        episode.id,
-                        episode.jellyfin_id,
+                if jf_series_id in unmatched_series_ids:
+                    continue  # series not found — don't flood warnings
+
+                series = series_by_jellyfin_series_id.get(jf_series_id)
+                if not series:
+                    if jf_series_id not in unmatched_series_ids:
+                        logger.warning(
+                            "Series not found for episode: jellyfin_series_id=%s", jf_series_id
+                        )
+                        unmatched_series_ids.add(jf_series_id)
+                    continue
+
+                episode = episodes_by_triple.get((series.id, season_num, ep_num))
+                if not episode:
+                    logger.warning(
+                        "Episode not found in DB: series_id=%d S%02dE%02d jellyfin_ep_id=%s",
+                        series.id,
+                        season_num,
+                        ep_num,
+                        jf_ep_id,
                     )
                     continue
+
+                # heal Episode.jellyfin_id
+                if jf_ep_id and episode.jellyfin_id != jf_ep_id:
+                    logger.info(
+                        "Healing Episode.jellyfin_id: id=%s old=%s new=%s",
+                        episode.id,
+                        episode.jellyfin_id,
+                        jf_ep_id,
+                    )
+                    episode.jellyfin_id = jf_ep_id
+
+                # heal Season.jellyfin_id
+                jf_season_id = ep_data.get("SeasonId")
+                if jf_season_id and episode.season and episode.season.jellyfin_id != jf_season_id:
+                    logger.info(
+                        "Healing Season.jellyfin_id: id=%s old=%s new=%s",
+                        episode.season.id,
+                        episode.season.jellyfin_id,
+                        jf_season_id,
+                    )
+                    episode.season.jellyfin_id = jf_season_id
+
+                resolved_episode_ids.add(episode.id)
 
                 user_data = ep_data.get("UserData") or {}
                 played = bool(user_data.get("Played"))
@@ -97,7 +245,6 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
                     jellyfin_status = WatchStatus.PLANNED
 
                 existing = watch_by_episode_id.get(episode.id)
-
                 if existing:
                     if existing.is_manual:
                         total_episodes_processed += 1
@@ -115,14 +262,13 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
                         user_updated += 1
                         watched_updated += 1
                 elif jellyfin_status in (WatchStatus.WATCHED, WatchStatus.WATCHING):
-                    media_id = episode.season.series.id
                     watched_at = (
                         parse_datetime(last_played_date_str) if last_played_date_str else None
                     )
                     to_insert.append(
                         {
                             "user_id": user.id,
-                            "media_id": media_id,
+                            "media_id": series.id,
                             "episode_id": episode.id,
                             "status": jellyfin_status,
                             "is_manual": False,
@@ -135,6 +281,22 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
 
                 total_episodes_processed += 1
 
+            # Step 9: dropped-detection via resolved_episode_ids (O(n))
+            for ep_id, wh in watch_by_episode_id.items():
+                if (
+                    ep_id not in resolved_episode_ids
+                    and wh.status in (WatchStatus.PLANNED, WatchStatus.WATCHING)
+                    and not wh.is_manual
+                ):
+                    wh.status = WatchStatus.DROPPED
+                    unwatched_marked += 1
+                    user_unwatched += 1
+                    logger.debug("Marked dropped episode_id=%s", ep_id)
+
+            # Step 10: bulk insert and commit
+            if to_insert:
+                await session.execute(insert(WatchHistory), to_insert)
+            await session.commit()
             logger.info(
                 "User %s: added=%d updated=%d unwatched=%d",
                 user.username,
@@ -142,23 +304,6 @@ async def sync_jellyfin_watched_series(session: AsyncSession) -> JellyfinWatched
                 user_updated,
                 user_unwatched,
             )
-
-            # Dropped detection: episodes that disappeared from Jellyfin
-            jellyfin_episode_ids = {ep["Id"] for ep in episodes_data if ep.get("Id")}
-            for ep_id, wh in watch_by_episode_id.items():
-                ep = next((e for e in episodes_by_jellyfin_id.values() if e.id == ep_id), None)
-                if (
-                    ep
-                    and ep.jellyfin_id not in jellyfin_episode_ids
-                    and wh.status in (WatchStatus.PLANNED, WatchStatus.WATCHING)
-                    and not wh.is_manual
-                ):
-                    wh.status = WatchStatus.DROPPED
-
-            if to_insert:
-                await session.execute(insert(WatchHistory), to_insert)
-
-            await session.commit()
 
         except Exception as e:
             await session.rollback()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -178,14 +178,21 @@ async def create_watch_history(
     return wh
 
 
-async def create_series(session, jellyfin_id=None, tmdb_id=None, imdb_id=None, title="Series"):
+async def create_series(
+    session, jellyfin_id=None, tmdb_id=None, imdb_id=None, tvdb_id=None, title="Series"
+):
     """Создает тестовый сериал."""
     media = MediaFactory(media_type=MediaType.SERIES, title=title)
     session.add(media)
     await session.flush()
 
     series = SeriesFactory(
-        id=media.id, jellyfin_id=jellyfin_id, tmdb_id=tmdb_id, imdb_id=imdb_id, media=media
+        id=media.id,
+        jellyfin_id=jellyfin_id,
+        tmdb_id=tmdb_id,
+        imdb_id=imdb_id,
+        tvdb_id=tvdb_id,
+        media=media,
     )
     session.add(series)
     media.series = series

--- a/backend/tests/integration/test_sync_jellyfin_watched_movies.py
+++ b/backend/tests/integration/test_sync_jellyfin_watched_movies.py
@@ -344,6 +344,50 @@ async def test_error_handling(session_no_expire, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_sync_heals_stale_jellyfin_id_via_tmdb(session_no_expire, monkeypatch):
+    """
+    Jellyfin_id в БД устарел, но tmdb_id совпадает — фильм должен быть найден
+    и jellyfin_id обновлён (heal-on-match).
+    """
+    _ = await create_user(session_no_expire, username="heal_user", jellyfin_user_id="jf_heal_1")
+    movie = await create_movie(
+        session_no_expire,
+        jellyfin_id="old-jellyfin-id",
+        tmdb_id="tmdb-heal-100",
+        imdb_id=None,
+    )
+    await session_no_expire.commit()
+
+    async def mock_fetch(url, api_key, jellyfin_user_id):
+        return [
+            JellyfinMovieDictFactory(
+                Id="new-jellyfin-id",
+                Name="Healed Movie",
+                ProviderIds={"Tmdb": "tmdb-heal-100"},
+                UserData={"Played": True, "LastPlayedDate": "2024-06-01T12:00:00Z"},
+            )
+        ]
+
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_movies_service.fetch_jellyfin_movies_for_user_all",
+        mock_fetch,
+    )
+
+    result = await sync_jellyfin_watched_movies(session_no_expire)
+    await session_no_expire.commit()
+
+    await session_no_expire.refresh(movie)
+
+    assert result.watched_added == 1
+    assert movie.jellyfin_id == "new-jellyfin-id"
+
+    watches = (await session_no_expire.execute(select(WatchHistory))).scalars().all()
+    assert len(watches) == 1
+    assert watches[0].media_id == movie.id
+    assert watches[0].status == WatchStatus.WATCHED
+
+
+@pytest.mark.asyncio
 async def test_no_movies_found(session_no_expire, monkeypatch):
     """Тест случая, когда у пользователя нет фильмов в Jellyfin"""
     _ = await create_user(session_no_expire, username="empty", jellyfin_user_id="jf_10")

--- a/backend/tests/integration/test_sync_jellyfin_watched_series.py
+++ b/backend/tests/integration/test_sync_jellyfin_watched_series.py
@@ -18,6 +18,24 @@ def mock_jellyfin_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_fetch_series_by_ids_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Default stub for fetch_jellyfin_series_by_ids.
+    Returns empty ProviderIds for every requested series ID so existing tests
+    (where series are already matched by jellyfin_id in DB) continue to pass.
+    Tests that need custom behaviour override this via their own monkeypatch.setattr.
+    """
+
+    async def _default(url, api_key, user_jellyfin_id, series_jellyfin_ids):
+        return [{"Id": sid, "ProviderIds": {}} for sid in series_jellyfin_ids]
+
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+        _default,
+    )
+
+
 async def test_sync_adds_watched_episode(session_no_expire, monkeypatch):
     """
     Тест добавления просмотренной серии.
@@ -125,11 +143,12 @@ async def test_sync_updates_existing_watched_episode(session_no_expire, monkeypa
                 Name="Episode to Update",
                 SeriesId="series_2",
                 SeasonId="season_2",
+                IndexNumber=1,
                 ParentIndexNumber=1,
                 ProviderIds={"Tmdb": "tmdb_200"},
                 UserData={
                     "Played": True,
-                    "LastPlayedDate": "2024-01-15T20:00:00Z",  # Новая дата просмотра
+                    "LastPlayedDate": "2024-01-15T20:00:00Z",
                 },
             ),
         ]
@@ -197,6 +216,7 @@ async def test_sync_marks_episode_unwatched(session_no_expire, monkeypatch):
                 Name="Episode to Unwatch",
                 SeriesId="series_3",
                 SeasonId="season_3",
+                IndexNumber=1,
                 ParentIndexNumber=1,
                 ProviderIds={"Tmdb": "tmdb_300"},
                 UserData={"Played": False},
@@ -262,6 +282,7 @@ async def test_sync_multiple_episodes_for_user(session_no_expire, monkeypatch):
                 Name="Episode 1",
                 SeriesId="series_4",
                 SeasonId="season_4",
+                IndexNumber=1,
                 ParentIndexNumber=1,
                 ProviderIds={"Tmdb": "tmdb_400"},
                 UserData={"Played": True, "LastPlayedDate": "2024-01-01T10:00:00Z"},
@@ -601,3 +622,117 @@ async def test_bulk_insert_of_watched_episodes(session_no_expire, monkeypatch):
     watched_episode_ids = {w.episode_id for w in watches}
     for episode in episodes:
         assert episode.id in watched_episode_ids
+
+
+@pytest.mark.asyncio
+async def test_sync_heals_stale_series_jellyfin_id_via_tvdb(session_no_expire, monkeypatch):
+    """
+    Series.jellyfin_id in DB is stale ("old-series").
+    Jellyfin returns episode with SeriesId="new-series".
+    fetch_jellyfin_series_by_ids maps "new-series" → Tvdb="tvdb-999" that matches DB series.
+    After sync: series.jellyfin_id must be updated to "new-series" and watched_added == 1.
+    """
+    _ = await create_user(session_no_expire, username="heal_s", jellyfin_user_id="jf_hs_1")
+    series = await create_series(
+        session_no_expire,
+        title="Healed Series",
+        jellyfin_id="old-series",
+        tvdb_id="tvdb-999",
+    )
+    season = await create_season(
+        session_no_expire, series_id=series.id, number=1, jellyfin_id="season-heal"
+    )
+    _ = await create_episode(
+        session_no_expire, season_id=season.id, number=1, title="Ep1", jellyfin_id="old-ep"
+    )
+    await session_no_expire.commit()
+
+    async def mock_fetch_episodes(url, api_key, jellyfin_user_id):
+        return [
+            JellyfinSeriesDictFactory(
+                Id="new-ep-id",
+                SeriesId="new-series",
+                SeasonId="new-season-id",
+                ParentIndexNumber=1,
+                IndexNumber=1,
+                UserData={"Played": True, "LastPlayedDate": "2024-06-01T12:00:00Z"},
+            )
+        ]
+
+    async def mock_fetch_series_by_ids(url, api_key, user_jellyfin_id, series_jellyfin_ids):
+        return [{"Id": "new-series", "ProviderIds": {"Tvdb": "tvdb-999"}}]
+
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
+        mock_fetch_episodes,
+    )
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+        mock_fetch_series_by_ids,
+    )
+
+    result = await sync_jellyfin_watched_series(session_no_expire)
+    await session_no_expire.commit()
+
+    await session_no_expire.refresh(series)
+    assert series.jellyfin_id == "new-series"
+    assert result.watched_added == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_heals_stale_episode_jellyfin_id_via_season_ep(session_no_expire, monkeypatch):
+    """
+    Episode.jellyfin_id in DB is stale ("old-ep-2").
+    Series is matched correctly by its unchanged jellyfin_id.
+    Jellyfin returns episode Id="new-ep-2" for S01E02.
+    After sync: episode.jellyfin_id must be updated to "new-ep-2" and watched_added == 1.
+    """
+    _ = await create_user(session_no_expire, username="heal_ep", jellyfin_user_id="jf_he_1")
+    series = await create_series(
+        session_no_expire,
+        title="Stable Series",
+        jellyfin_id="jf-series-stable",
+        tvdb_id="tvdb-stable",
+    )
+    season = await create_season(
+        session_no_expire, series_id=series.id, number=1, jellyfin_id="season-stable"
+    )
+    episode = await create_episode(
+        session_no_expire,
+        season_id=season.id,
+        number=2,
+        title="Ep2",
+        jellyfin_id="old-ep-2",
+    )
+    await session_no_expire.commit()
+
+    async def mock_fetch_episodes(url, api_key, jellyfin_user_id):
+        return [
+            JellyfinSeriesDictFactory(
+                Id="new-ep-2",
+                SeriesId="jf-series-stable",
+                SeasonId="season-stable",
+                ParentIndexNumber=1,
+                IndexNumber=2,
+                UserData={"Played": True, "LastPlayedDate": "2024-07-01T12:00:00Z"},
+            )
+        ]
+
+    async def mock_fetch_series_by_ids(url, api_key, user_jellyfin_id, series_jellyfin_ids):
+        return [{"Id": "jf-series-stable", "ProviderIds": {}}]
+
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
+        mock_fetch_episodes,
+    )
+    monkeypatch.setattr(
+        "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+        mock_fetch_series_by_ids,
+    )
+
+    result = await sync_jellyfin_watched_series(session_no_expire)
+    await session_no_expire.commit()
+
+    await session_no_expire.refresh(episode)
+    assert episode.jellyfin_id == "new-ep-2"
+    assert result.watched_added == 1

--- a/backend/tests/units/test_service/test_jellyfin_watched_episodes.py
+++ b/backend/tests/units/test_service/test_jellyfin_watched_episodes.py
@@ -6,6 +6,7 @@ from app.models.user import WatchStatus
 from app.services.sync_jellyfin_watched_series_service import (
     sync_jellyfin_watched_series,
 )
+from tests.factories import EpisodeFactory, SeasonFactory, SeriesFactory, UserFactory
 
 
 @pytest.mark.asyncio
@@ -42,34 +43,26 @@ async def test_sync_watched_episodes_no_episodes(mock_session, user):
 @pytest.mark.asyncio
 async def test_sync_watched_episodes_add_new(mock_session, user, episode, season, series):
     episode.season = season
-    season.series = series
+    season.series_id = series.id
 
     episode_data = {
-        "Id": episode.jellyfin_id,
+        "Id": "new-ep-jf",
+        "SeriesId": series.jellyfin_id,
+        "ParentIndexNumber": season.number,
+        "IndexNumber": episode.number,
         "UserData": {
             "Played": True,
             "LastPlayedDate": "2024-01-01T10:00:00Z",
         },
     }
 
-    users_result = MagicMock()
-    users_result.scalars.return_value.all.return_value = [user]
-
-    episodes_scalars = MagicMock()
-    episodes_scalars.__iter__.return_value = iter([episode])
-    episodes_result = MagicMock()
-    episodes_result.scalars.return_value = episodes_scalars
-
-    wh_scalars = MagicMock()
-    wh_scalars.__iter__.return_value = iter([])
-    wh_result = MagicMock()
-    wh_result.scalars.return_value = wh_scalars
-
     mock_session.execute = AsyncMock(
         side_effect=[
-            users_result,  # users
-            episodes_result,  # episodes
-            wh_result,  # watch history
+            _make_scalars_all([user]),  # users
+            _make_scalars_all([series]),  # series lookup
+            _make_scalars_all([season]),  # seasons
+            _make_scalars_all([episode]),  # episodes
+            _make_scalars_iter([]),  # watch history
             MagicMock(),  # insert
         ]
     )
@@ -83,20 +76,23 @@ async def test_sync_watched_episodes_add_new(mock_session, user, episode, season
         patch(
             "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
             new_callable=AsyncMock,
-        ) as mock_fetch,
+            return_value=[episode_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            return_value=[{"Id": series.jellyfin_id, "ProviderIds": {}}],
+        ),
         patch(
             "app.services.sync_jellyfin_watched_series_service.parse_datetime",
             return_value="parsed-date",
         ),
     ):
-        mock_fetch.return_value = [episode_data]
-
         result = await sync_jellyfin_watched_series(mock_session)
 
         assert result.watched_added == 1
         assert result.watched_updated == 0
         assert result.unwatched_marked == 0
-
         mock_session.commit.assert_called()
 
 
@@ -105,33 +101,31 @@ async def test_sync_watched_episodes_update_existing(
     mock_session, user, episode, season, series, existing_watch
 ):
     episode.season = season
-    season.series = series
+    season.series_id = series.id
 
     existing_watch.episode_id = episode.id
     existing_watch.status = WatchStatus.PLANNED
+    existing_watch.is_manual = False
+    existing_watch.watched_at = None
 
     episode_data = {
         "Id": episode.jellyfin_id,
+        "SeriesId": series.jellyfin_id,
+        "ParentIndexNumber": season.number,
+        "IndexNumber": episode.number,
         "UserData": {
             "Played": True,
             "LastPlayedDate": "2024-01-02T10:00:00Z",
         },
     }
 
-    users_result = MagicMock()
-    users_result.scalars.return_value.all.return_value = [user]
-
-    episodes_result = MagicMock()
-    episodes_result.scalars.return_value.__iter__.return_value = iter([episode])
-
-    wh_result = MagicMock()
-    wh_result.scalars.return_value.__iter__.return_value = iter([existing_watch])
-
     mock_session.execute = AsyncMock(
         side_effect=[
-            users_result,
-            episodes_result,
-            wh_result,
+            _make_scalars_all([user]),
+            _make_scalars_all([series]),
+            _make_scalars_all([season]),
+            _make_scalars_all([episode]),
+            _make_scalars_iter([existing_watch]),
         ]
     )
 
@@ -144,20 +138,23 @@ async def test_sync_watched_episodes_update_existing(
         patch(
             "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
             new_callable=AsyncMock,
-        ) as mock_fetch,
+            return_value=[episode_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            return_value=[{"Id": series.jellyfin_id, "ProviderIds": {}}],
+        ),
         patch(
             "app.services.sync_jellyfin_watched_series_service.parse_datetime",
             return_value="parsed-date",
         ),
     ):
-        mock_fetch.return_value = [episode_data]
-
         result = await sync_jellyfin_watched_series(mock_session)
 
         assert result.watched_updated == 1
         assert existing_watch.status == WatchStatus.WATCHED
         assert existing_watch.watched_at == "parsed-date"
-
         mock_session.commit.assert_called()
 
 
@@ -166,30 +163,239 @@ async def test_sync_watched_episodes_mark_unwatched(
     mock_session, user, episode, season, series, existing_watch
 ):
     episode.season = season
-    season.series = series
+    season.series_id = series.id
 
     existing_watch.episode_id = episode.id
     existing_watch.status = WatchStatus.WATCHED
+    existing_watch.is_manual = False
 
     episode_data = {
         "Id": episode.jellyfin_id,
+        "SeriesId": series.jellyfin_id,
+        "ParentIndexNumber": season.number,
+        "IndexNumber": episode.number,
         "UserData": {
             "Played": False,
+            "PlaybackPositionTicks": 0,
         },
     }
 
-    users_result = MagicMock()
-    users_result.scalars.return_value.all.return_value = [user]
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            _make_scalars_all([user]),
+            _make_scalars_all([series]),
+            _make_scalars_all([season]),
+            _make_scalars_all([episode]),
+            _make_scalars_iter([existing_watch]),
+        ]
+    )
 
-    episodes_result = MagicMock()
-    episodes_result.scalars.return_value.__iter__.return_value = iter([episode])
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[episode_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            return_value=[{"Id": series.jellyfin_id, "ProviderIds": {}}],
+        ),
+    ):
+        result = await sync_jellyfin_watched_series(mock_session)
 
-    wh_result = MagicMock()
-    wh_result.scalars.return_value.__iter__.return_value = iter([existing_watch])
+        assert result.watched_updated == 1
+        assert existing_watch.status == WatchStatus.PLANNED
+        mock_session.commit.assert_called()
+
+
+def _make_scalars_all(items):
+    """Helper: mock result supporting .scalars().all()"""
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def _make_scalars_iter(items):
+    """Helper: mock result supporting iteration over .scalars()"""
+    scalars = MagicMock()
+    scalars.__iter__ = MagicMock(return_value=iter(items))
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+@pytest.mark.asyncio
+async def test_sync_heals_series_jellyfin_id_on_tvdb_match(mock_session):
+    """
+    Series in DB has stale jellyfin_id. Jellyfin episode payload carries new SeriesId.
+    fetch_jellyfin_series_by_ids resolves the new SeriesId to Tvdb that matches DB series.
+    After sync the series object must have its jellyfin_id updated (heal-on-match).
+    """
+    user = UserFactory.build(id=1, jellyfin_user_id="jf-user-1")
+    series = SeriesFactory.build(
+        id=10, jellyfin_id="old-series-jf", tvdb_id="tvdb-123", imdb_id=None
+    )
+    season = SeasonFactory.build(id=5, series_id=series.id, number=1)
+    episode = EpisodeFactory.build(id=20, season_id=season.id, number=1, jellyfin_id="ep-jf-1")
+    episode.season = season
+
+    ep_data = {
+        "Id": "ep-jf-1",
+        "SeriesId": "new-series-jf",
+        "ParentIndexNumber": 1,
+        "IndexNumber": 1,
+        "UserData": {"Played": True, "LastPlayedDate": "2024-03-01T10:00:00Z"},
+    }
+
+    # SQL order: users → series lookup → seasons → episodes → watch_history → insert
+    users_result = _make_scalars_all([user])
+    series_result = _make_scalars_all([series])
+    seasons_result = _make_scalars_all([season])
+    episodes_result = _make_scalars_all([episode])
+    wh_result = _make_scalars_iter([])
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            users_result,  # 1. select(User)
+            series_result,  # 2. select(Series).where(or_(...))
+            seasons_result,  # 3. select(Season)
+            episodes_result,  # 4. select(Episode)
+            wh_result,  # 5. select(WatchHistory)
+            MagicMock(),  # 6. insert(WatchHistory)
+        ]
+    )
+
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[ep_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            return_value=[{"Id": "new-series-jf", "ProviderIds": {"Tvdb": "tvdb-123"}}],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.parse_datetime",
+            return_value="parsed-date",
+        ),
+    ):
+        result = await sync_jellyfin_watched_series(mock_session)
+
+    # heal must have updated the in-memory object
+    assert series.jellyfin_id == "new-series-jf"
+    assert result.watched_added == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_heals_episode_jellyfin_id_on_season_ep_match(mock_session):
+    """
+    Episode in DB has stale jellyfin_id. Series is matched by its (correct) jellyfin_id.
+    Jellyfin episode payload carries a new episode Id for the same S01E01.
+    After sync the episode object must have its jellyfin_id updated (heal-on-match).
+    """
+    user = UserFactory.build(id=1, jellyfin_user_id="jf-user-2")
+    series = SeriesFactory.build(id=11, jellyfin_id="jf-series-1", tvdb_id="tvdb-456", imdb_id=None)
+    season = SeasonFactory.build(id=6, series_id=series.id, number=1)
+    episode = EpisodeFactory.build(id=21, season_id=season.id, number=1, jellyfin_id="old-ep-jf")
+    episode.season = season
+
+    ep_data = {
+        "Id": "new-ep-jf",
+        "SeriesId": "jf-series-1",
+        "ParentIndexNumber": 1,
+        "IndexNumber": 1,
+        "UserData": {"Played": True, "LastPlayedDate": "2024-04-01T10:00:00Z"},
+    }
+
+    users_result = _make_scalars_all([user])
+    series_result = _make_scalars_all([series])
+    seasons_result = _make_scalars_all([season])
+    episodes_result = _make_scalars_all([episode])
+    wh_result = _make_scalars_iter([])
 
     mock_session.execute = AsyncMock(
         side_effect=[
             users_result,
+            series_result,
+            seasons_result,
+            episodes_result,
+            wh_result,
+            MagicMock(),  # insert
+        ]
+    )
+
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[ep_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            # series matched by jellyfin_id directly — provider IDs not needed for resolve
+            return_value=[{"Id": "jf-series-1", "ProviderIds": {}}],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.parse_datetime",
+            return_value="parsed-date",
+        ),
+    ):
+        result = await sync_jellyfin_watched_series(mock_session)
+
+    assert episode.jellyfin_id == "new-ep-jf"
+    assert result.watched_added == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_series_not_found_skips_all_episodes(mock_session):
+    """
+    fetch_jellyfin_series_by_ids returns an empty list — provider IDs are unknown.
+    The series cannot be resolved by any ID, so all episodes are skipped.
+    watched_added must stay 0.
+    """
+    user = UserFactory.build(id=1, jellyfin_user_id="jf-user-3")
+
+    ep_data = {
+        "Id": "ep-x",
+        "SeriesId": "unknown-series-jf",
+        "ParentIndexNumber": 1,
+        "IndexNumber": 1,
+        "UserData": {"Played": True, "LastPlayedDate": "2024-05-01T10:00:00Z"},
+    }
+
+    users_result = _make_scalars_all([user])
+    # Series DB query returns nothing — no match
+    series_result = _make_scalars_all([])
+    seasons_result = _make_scalars_all([])
+    episodes_result = _make_scalars_all([])
+    wh_result = _make_scalars_iter([])
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            users_result,
+            series_result,
+            seasons_result,
             episodes_result,
             wh_result,
         ]
@@ -204,13 +410,16 @@ async def test_sync_watched_episodes_mark_unwatched(
         patch(
             "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_episodes_for_user_all",
             new_callable=AsyncMock,
-        ) as mock_fetch,
+            return_value=[ep_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_series_service.fetch_jellyfin_series_by_ids",
+            new_callable=AsyncMock,
+            # Empty list — no provider IDs available, series can't be resolved
+            return_value=[],
+        ),
     ):
-        mock_fetch.return_value = [episode_data]
-
         result = await sync_jellyfin_watched_series(mock_session)
 
-        assert result.watched_updated == 1
-        assert existing_watch.status == WatchStatus.PLANNED
-
-        mock_session.commit.assert_called()
+    assert result.watched_added == 0
+    assert result.watched_updated == 0

--- a/backend/tests/units/test_service/test_jellyfin_watched_movies.py
+++ b/backend/tests/units/test_service/test_jellyfin_watched_movies.py
@@ -251,3 +251,175 @@ async def test_sync_watched_movies_mark_unwatched(mock_session, user, movie, exi
         assert existing_watch.status == WatchStatus.PLANNED
 
         mock_session.commit.assert_called()
+
+
+def _make_scalars_all(items):
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = items
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+    return result_mock
+
+
+def _make_scalars_iter(items):
+    scalars_mock = MagicMock()
+    scalars_mock.__iter__.return_value = iter(items)
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+    return result_mock
+
+
+@pytest.mark.asyncio
+async def test_sync_heals_jellyfin_id_on_tmdb_match(mock_session, user, movie):
+    """
+    Фильм в БД с jellyfin_id="old-jf-id" и tmdb_id="123".
+    Jellyfin возвращает тот же фильм с Id="new-jf-id" и ProviderIds={"Tmdb":"123"}.
+    После синка movie.jellyfin_id должен стать "new-jf-id" (heal-on-match).
+    """
+    movie.jellyfin_id = "old-jf-id"
+    movie.tmdb_id = "123"
+
+    movie_data = {
+        "Id": "new-jf-id",
+        "Name": "Healed Movie",
+        "ProviderIds": {"Tmdb": "123"},
+        "UserData": {"Played": True, "LastPlayedDate": "2024-06-01T10:00:00Z"},
+    }
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            _make_scalars_all([user]),  # 1. select(User)
+            _make_scalars_iter([]),  # 2. select(WatchHistory)
+            _make_scalars_iter([]),  # 3. select(Movie).where(jellyfin_id.in_("new-jf-id")) → miss
+            _make_scalars_iter([movie]),  # 4. select(Movie).where(tmdb_id.in_("123")) → hit
+            # no 5th call: ProviderIds has no Imdb → imdb_ids is empty
+        ]
+    )
+
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.fetch_jellyfin_movies_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[movie_data],
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.parse_datetime",
+            return_value="parsed-date",
+        ),
+    ):
+        result = await sync_jellyfin_watched_movies(mock_session)
+
+    assert result.watched_added == 1
+    assert movie.jellyfin_id == "new-jf-id"
+
+
+@pytest.mark.asyncio
+async def test_sync_movie_not_found_logs_warning(mock_session, user, caplog):
+    """
+    Все три словаря пусты — фильм не найден ни по одному ID.
+    Проверяем, что warning залогирован и счётчики равны нулю.
+    """
+    movie_data = {
+        "Id": "unknown-jf-id",
+        "Name": "Ghost Movie",
+        "ProviderIds": {"Tmdb": "999", "Imdb": "tt999"},
+        "UserData": {"Played": True},
+    }
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            _make_scalars_all([user]),  # 1. select(User)
+            _make_scalars_iter([]),  # 2. select(WatchHistory)
+            _make_scalars_iter([]),  # 3. select(Movie).where(jellyfin_id.in_(...))
+            _make_scalars_iter([]),  # 4. select(Movie).where(tmdb_id.in_(...))
+            _make_scalars_iter([]),  # 5. select(Movie).where(imdb_id.in_(...))
+        ]
+    )
+
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.fetch_jellyfin_movies_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[movie_data],
+        ),
+    ):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="media_tracker"):
+            result = await sync_jellyfin_watched_movies(mock_session)
+
+    assert result.watched_added == 0
+    assert result.watched_updated == 0
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warning_records, "Expected at least one WARNING log record, got none"
+    warning_text = " ".join(r.getMessage() for r in warning_records)
+    assert (
+        "Movie not found in DB" in warning_text or "Ghost Movie" in warning_text
+    ), f"Expected 'Movie not found in DB' warning, got: {warning_text}"
+
+
+@pytest.mark.asyncio
+async def test_sync_dropped_detection_uses_resolved_ids(mock_session, user, movie):
+    """
+    WatchHistory с status=PLANNED для фильма, которого нет в Jellyfin.
+    Jellyfin возвращает другой фильм с неизвестными ID — movie из WatchHistory
+    не попадает в jellyfin_media_ids, поэтому его статус должен стать DROPPED.
+    """
+    movie.jellyfin_id = "db-movie-jf"
+    movie.tmdb_id = "db-tmdb"
+    movie.imdb_id = None
+
+    planned_watch = MagicMock()
+    planned_watch.media_id = movie.id
+    planned_watch.status = WatchStatus.PLANNED
+    planned_watch.is_manual = False
+
+    # Jellyfin returns a completely different movie (IDs not in DB)
+    jellyfin_movie_data = {
+        "Id": "unknown-jf-id",
+        "Name": "Unknown Movie",
+        "ProviderIds": {"Tmdb": "unknown-tmdb"},
+        "UserData": {"Played": False},
+    }
+
+    # DB queries for the unknown Jellyfin movie's IDs return empty results.
+    # imdb_ids is empty so there are only 4 execute calls (no 5th for imdb).
+    empty_iter = _make_scalars_iter([])
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            _make_scalars_all([user]),  # 1. select(User)
+            _make_scalars_iter([planned_watch]),  # 2. select(WatchHistory)
+            empty_iter,  # 3. select(Movie).where(jellyfin_id.in_(...))
+            empty_iter,  # 4. select(Movie).where(tmdb_id.in_(...))
+            # no 5th call: imdb_ids is empty → no query
+        ]
+    )
+
+    with (
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.get_decrypted_config",
+            new_callable=AsyncMock,
+            return_value=("http://jellyfin:8096", "test-api-key"),
+        ),
+        patch(
+            "app.services.sync_jellyfin_watched_movies_service.fetch_jellyfin_movies_for_user_all",
+            new_callable=AsyncMock,
+            return_value=[jellyfin_movie_data],
+        ),
+    ):
+        result = await sync_jellyfin_watched_movies(mock_session)
+
+    assert result.unwatched_marked == 1
+    assert planned_watch.status == WatchStatus.DROPPED

--- a/backend/tests/units/test_service/test_resolve_movie_from_indexes.py
+++ b/backend/tests/units/test_service/test_resolve_movie_from_indexes.py
@@ -1,0 +1,113 @@
+from app.services.movie_utils import resolve_movie_from_indexes
+from tests.factories import MovieFactory
+
+
+def test_resolve_by_jellyfin_id() -> None:
+    """jellyfin_id совпадает — возвращается нужный Movie."""
+    target = MovieFactory.build(jellyfin_id="jf-abc", tmdb_id="tmdb-1", imdb_id="tt-1")
+    other = MovieFactory.build(jellyfin_id="jf-other", tmdb_id="tmdb-other", imdb_id="tt-other")
+
+    result = resolve_movie_from_indexes(
+        jellyfin_id="jf-abc",
+        tmdb_id=None,
+        imdb_id=None,
+        by_jellyfin_id={"jf-abc": target, "jf-other": other},
+        by_tmdb_id={},
+        by_imdb_id={},
+    )
+
+    assert result is target
+
+
+def test_resolve_by_tmdb_id_when_jellyfin_miss() -> None:
+    """jellyfin_id отсутствует в словаре, tmdb_id совпадает — возвращается Movie по tmdb."""
+    target = MovieFactory.build(jellyfin_id=None, tmdb_id="tmdb-999", imdb_id="tt-999")
+
+    result = resolve_movie_from_indexes(
+        jellyfin_id="jf-unknown",
+        tmdb_id="tmdb-999",
+        imdb_id=None,
+        by_jellyfin_id={},
+        by_tmdb_id={"tmdb-999": target},
+        by_imdb_id={},
+    )
+
+    assert result is target
+
+
+def test_resolve_by_imdb_id_when_others_miss() -> None:
+    """jellyfin_id и tmdb_id не совпадают, только imdb_id совпадает — возвращается Movie по imdb."""
+    target = MovieFactory.build(jellyfin_id=None, tmdb_id=None, imdb_id="tt-777")
+
+    result = resolve_movie_from_indexes(
+        jellyfin_id="jf-miss",
+        tmdb_id="tmdb-miss",
+        imdb_id="tt-777",
+        by_jellyfin_id={},
+        by_tmdb_id={},
+        by_imdb_id={"tt-777": target},
+    )
+
+    assert result is target
+
+
+def test_resolve_returns_none_when_all_miss() -> None:
+    """Все три словаря пусты — возвращается None."""
+    result = resolve_movie_from_indexes(
+        jellyfin_id="jf-x",
+        tmdb_id="tmdb-x",
+        imdb_id="tt-x",
+        by_jellyfin_id={},
+        by_tmdb_id={},
+        by_imdb_id={},
+    )
+
+    assert result is None
+
+
+def test_resolve_jellyfin_id_takes_priority_over_tmdb() -> None:
+    """Один Movie в by_jellyfin_id, другой в by_tmdb_id — возвращается из by_jellyfin_id."""
+    jellyfin_movie = MovieFactory.build(jellyfin_id="jf-1", tmdb_id="tmdb-1")
+    tmdb_movie = MovieFactory.build(jellyfin_id=None, tmdb_id="tmdb-1")
+
+    result = resolve_movie_from_indexes(
+        jellyfin_id="jf-1",
+        tmdb_id="tmdb-1",
+        imdb_id=None,
+        by_jellyfin_id={"jf-1": jellyfin_movie},
+        by_tmdb_id={"tmdb-1": tmdb_movie},
+        by_imdb_id={},
+    )
+
+    assert result is jellyfin_movie
+    assert result is not tmdb_movie
+
+
+def test_resolve_with_none_jellyfin_id() -> None:
+    """jellyfin_id=None — первая ступень пропускается, Movie находится по tmdb_id."""
+    target = MovieFactory.build(jellyfin_id=None, tmdb_id="tmdb-42")
+
+    result = resolve_movie_from_indexes(
+        jellyfin_id=None,
+        tmdb_id="tmdb-42",
+        imdb_id=None,
+        by_jellyfin_id={"tmdb-42": MovieFactory.build()},  # ключ не совпадёт — jellyfin_id None
+        by_tmdb_id={"tmdb-42": target},
+        by_imdb_id={},
+    )
+
+    assert result is target
+
+
+def test_resolve_with_all_none_ids() -> None:
+    """Все три ID равны None — ни одна ступень не срабатывает, возвращается None."""
+    result = resolve_movie_from_indexes(
+        jellyfin_id=None,
+        tmdb_id=None,
+        imdb_id=None,
+        by_jellyfin_id={"some-id": MovieFactory.build()},
+        by_tmdb_id={"tmdb-1": MovieFactory.build()},
+        by_imdb_id={"tt-1": MovieFactory.build()},
+    )
+
+    assert result is None

--- a/backend/tests/units/test_service/test_resolve_series_from_indexes.py
+++ b/backend/tests/units/test_service/test_resolve_series_from_indexes.py
@@ -1,0 +1,98 @@
+from app.services.series_utils import resolve_series_from_indexes
+from tests.factories import SeriesFactory
+
+
+def test_resolve_by_jellyfin_id() -> None:
+    """Матч по jellyfin_id — возвращает нужный Series."""
+    series = SeriesFactory.build(id=1, jellyfin_id="jf-111", tvdb_id="tvdb-111", imdb_id="tt111")
+
+    result = resolve_series_from_indexes(
+        jellyfin_id="jf-111",
+        tvdb_id="tvdb-111",
+        imdb_id="tt111",
+        by_jellyfin_id={"jf-111": series},
+        by_tvdb_id={},
+        by_imdb_id={},
+    )
+
+    assert result is series
+
+
+def test_resolve_by_tvdb_id_when_jellyfin_miss() -> None:
+    """jellyfin_id не найден, матч по tvdb_id — возвращает нужный Series."""
+    series = SeriesFactory.build(id=2, jellyfin_id="jf-old", tvdb_id="tvdb-222", imdb_id="tt222")
+
+    result = resolve_series_from_indexes(
+        jellyfin_id="jf-not-in-index",
+        tvdb_id="tvdb-222",
+        imdb_id="tt222",
+        by_jellyfin_id={},
+        by_tvdb_id={"tvdb-222": series},
+        by_imdb_id={},
+    )
+
+    assert result is series
+
+
+def test_resolve_by_imdb_id_when_others_miss() -> None:
+    """jellyfin_id и tvdb_id не найдены, матч по imdb_id — возвращает нужный Series."""
+    series = SeriesFactory.build(id=3, jellyfin_id="jf-old", tvdb_id="tvdb-old", imdb_id="tt333")
+
+    result = resolve_series_from_indexes(
+        jellyfin_id="jf-not-present",
+        tvdb_id="tvdb-not-present",
+        imdb_id="tt333",
+        by_jellyfin_id={},
+        by_tvdb_id={},
+        by_imdb_id={"tt333": series},
+    )
+
+    assert result is series
+
+
+def test_resolve_returns_none_when_all_miss() -> None:
+    """Все три словаря пусты — возвращает None."""
+    result = resolve_series_from_indexes(
+        jellyfin_id="jf-x",
+        tvdb_id="tvdb-x",
+        imdb_id="tt-x",
+        by_jellyfin_id={},
+        by_tvdb_id={},
+        by_imdb_id={},
+    )
+
+    assert result is None
+
+
+def test_resolve_jellyfin_id_takes_priority_over_tvdb() -> None:
+    """jellyfin_id имеет приоритет над tvdb_id — возвращается объект из by_jellyfin_id."""
+    series_by_jf = SeriesFactory.build(id=10, jellyfin_id="jf-priority", tvdb_id="tvdb-shared")
+    series_by_tvdb = SeriesFactory.build(id=20, jellyfin_id="jf-other", tvdb_id="tvdb-shared")
+
+    result = resolve_series_from_indexes(
+        jellyfin_id="jf-priority",
+        tvdb_id="tvdb-shared",
+        imdb_id=None,
+        by_jellyfin_id={"jf-priority": series_by_jf},
+        by_tvdb_id={"tvdb-shared": series_by_tvdb},
+        by_imdb_id={},
+    )
+
+    assert result is series_by_jf
+    assert result is not series_by_tvdb
+
+
+def test_resolve_with_all_none_ids() -> None:
+    """Все три ID равны None — пропускает все ступени и возвращает None."""
+    series = SeriesFactory.build(id=5, jellyfin_id="jf-5", tvdb_id="tvdb-5", imdb_id="tt5")
+
+    result = resolve_series_from_indexes(
+        jellyfin_id=None,
+        tvdb_id=None,
+        imdb_id=None,
+        by_jellyfin_id={"jf-5": series},
+        by_tvdb_id={"tvdb-5": series},
+        by_imdb_id={"tt5": series},
+    )
+
+    assert result is None


### PR DESCRIPTION
Jellyfin regenerates item IDs when files are replaced by better quality versions (Sonarr/Radarr upgrades). The previous sync matched exclusively by jellyfin_id causing silent add=0/update=0 on every quality upgrade.

New matching strategy:
- Series: jellyfin_id → tvdb_id → imdb_id (fast path + fallback)
- Movies: jellyfin_id → tmdb_id → imdb_id
- Episodes: (series_id, season_number, episode_number) triple

When a stale jellyfin_id is detected via external ID fallback, it is updated in the same transaction (heal-on-match), so subsequent syncs use the fast path again.

Also fixes: unwatched_marked counter not incrementing in series dropped-detection, movie not-found logged at debug instead of warning, O(n*m) loop in dropped-detection replaced with O(n) set lookup.